### PR TITLE
Ability to select alternate top level project folder by prefixing path with <name>:

### DIFF
--- a/AdvancedNewFile.py
+++ b/AdvancedNewFile.py
@@ -10,6 +10,7 @@ class AdvancedNewFileCommand(sublime_plugin.TextCommand):
         self.root = self.get_root()
         self.is_python = is_python
         self.show_filename_input()
+        self.top_level_split_char = ":"
 
     def get_root(self, target=None):
         try:
@@ -40,14 +41,10 @@ class AdvancedNewFileCommand(sublime_plugin.TextCommand):
     def entered_filename(self, filename):
         base = self.root
         
-        if ":" in filename:
-            parts = filename.split(":")
-            # someone did something 
-            # weird lets bail
-            if len(parts) > 2:
-                return
-            filename = parts[1]
+        if self.top_level_split_char in filename:
+            parts = filename.split(self.top_level_split_char)
             base = self.get_root(parts[0])
+            filename = self.top_level_split_char.join(parts[1:])
 
         file_path = os.path.join(base, filename)
 


### PR DESCRIPTION
If you have multiple top level project folders, the current behavior is to default to _self.window.folders()[0]_.  This amendment allows you to specify an alternate top level project folder in the path creation string.

For example, if you have 2 top level project folders in the sublime project window:

```
    foo/
        stuff.py

    bar/
        other_stuff.py
```

launching the dialog and typing in:
**tests/test_stuff.py**

would, by default, create a tests folder containing test_stuff.py, leaving us with the following:

```
    foo/
        stuff.py
        tests/
            test_stuff.py

    bar/
        other_stuff.py
```

but what if we wanted to target 'bar' for the file creation?  Now you can:

Launching the dialog and typing in:
**bar:tests/test_other_stuff.py**

Note the _<name>:_  prefix

This would now leave us with the following:

```
    foo/
        stuff.py
        tests/
            test_stuff.py

    bar/
        other_stuff.py
        tests/
            test_other_stuff.py
```

What if someone types in a non-existant top level folder?

Launching the dialog and typing in:
**fkdsjfksdk:tests/test_other_stuff.py**

It will default to:
_self.window.folders()[0]_

Additionally what if someone does something funky:
**bar:lets:mess:it:up/test.py**

The result would be:

```
    foo/
        stuff.py
        tests/
            test_stuff.py

    bar/
        other_stuff.py
        lets:mess:it:up/
            test.py

        tests/
            test_other_stuff.py
```

An idea for one more optimization **not** currently present:
**bar:lets:mess:it:up/test.py**

Would be converted too:
**bar:lets/mess/it/up/test.py**
