### PR TITLE
Updated package installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Installation through [package control](http://wbond.net/sublime_packages/package
 
 * In the Command Palette, enter `Package Control: Install Package`
 * Search for `AdvancedNewFile`
+* In the Command Palette, enter `Package Control :Enable Package` -> select AdvancedNewFile
 
 ### Manual
 Clone or copy this repository into the packages directory. By default, they are located at:


### PR DESCRIPTION
The super+alt+n keybinding wasn't working for me after installing the package. Tried to find keybinding conflicts - finally got it working by 'enabling the package'. Might help someone else out.
