### PR TITLE
Option to allow sidebar to refresh.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.pyc
+.DS_Store

--- a/AdvancedNewFile.py
+++ b/AdvancedNewFile.py
@@ -18,7 +18,8 @@ SETTINGS = [
     "alias_root",
     "alias_path",
     "alias_folder_index",
-    "debug"
+    "debug",
+    "auto_refresh_sidebar"
 ]
 VIEW_NAME = "AdvancedNewFileCreation"
 WIN_ROOT_REGEX = r"[a-zA-Z]:(/|\\)"
@@ -43,6 +44,7 @@ class AdvancedNewFileCommand(sublime_plugin.WindowCommand):
         settings = get_settings(self.view)
         self.aliases = self.get_aliases(settings)
         self.show_path = settings.get("show_path")
+        self.auto_refresh_sidebar = settings.get("auto_refresh_sidebar")
         self.default_folder_index = settings.get("default_folder_index")
         self.alias_folder_index = settings.get("alias_folder_index")
         default_root = self.get_default_root(settings.get("default_root"))
@@ -265,6 +267,15 @@ class AdvancedNewFileCommand(sublime_plugin.WindowCommand):
                 else:
                     self.window.open_file(file_path)
         self.clear()
+        self.refresh_sidebar()
+
+    def refresh_sidebar(self):
+        if self.auto_refresh_sidebar:
+            try:
+                self.window.run_command("refresh_folder_list")
+            except:
+                pass
+
 
     def clear(self):
         if self.view != None:

--- a/AdvancedNewFile.sublime-settings
+++ b/AdvancedNewFile.sublime-settings
@@ -70,5 +70,11 @@
 
     // A boolean specifying if case should be ignored when building
     // auto complete list.
-    "ignore_case": false
+    "ignore_case": false,
+
+    // A boolean specifying if folders should automatically refresh and update the sidebar.
+    // In some builds, the sidebar does not refresh when contents of project folder are updated.
+    // This setting is required to refresh the sidebar in these circumstances.
+    // false by default
+    "auto_refresh_sidebar": false
 }


### PR DESCRIPTION
For some users, the sidebar does not update as files and folders change. This option allows refreshing of sidebar without manually going to Project > Refresh Folders.
