### PR TITLE
README.md: Fix little path typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,13 @@ Installation through [package control](http://wbond.net/sublime_packages/package
 Clone or copy this repository into the packages directory. You will need to rename the folder to `AdvancedNewFile` if using this method. By default, the Package directory is located at:
 
 * OS X: ~/Library/Application Support/Sublime Text 2/Packages/
-* Windows: %APPDATA%/Roaming/Sublime Text 2/Packages/
+* Windows: %APPDATA%/Sublime Text 2/Packages/
 * Linux: ~/.config/sublime-text-2/Packages/
 
 or
 
 * OS X: ~/Library/Application Support/Sublime Text 3/Packages/
-* Windows: %APPDATA%/Roaming/Sublime Text 3/Packages/
+* Windows: %APPDATA%/Sublime Text 3/Packages/
 * Linux: ~/.config/sublime-text-3/Packages/
 
 ## Usage


### PR DESCRIPTION
// Exuse my beginner's English.

I fix windows specific path in the chapter Installation > Manual > Windows.
In Windows 7  `%APPDATA%` variable equal with `C:\Users\%username%\AppData\Roaming\` path.
