### PR TITLE
Use Side-by-Side settings

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -1,8 +1,43 @@
 [
-  { "caption": "ANF: New File", "command": "advanced_new_file_new" },
-  { "caption": "ANF: Rename File", "command": "advanced_new_file_move"},
-  { "caption": "ANF: Delete File", "command": "advanced_new_file_delete"},
-  { "caption": "ANF: Delete Current File", "command": "advanced_new_file_delete", "args": {"current": true}},
-  { "caption": "ANF: Copy Current File", "command": "advanced_new_file_copy" },
-  { "caption": "ANF: Cut to File", "command": "advanced_new_file_cut_to_file" }
+	{
+		"caption": "ANF: New File",
+		"command": "advanced_new_file_new"
+	},
+	{
+		"caption": "ANF: Rename File",
+		"command": "advanced_new_file_move"
+	},
+	{
+		"caption": "ANF: Delete File",
+		"command": "advanced_new_file_delete"
+	},
+	{
+		"caption": "ANF: Delete Current File",
+		"command": "advanced_new_file_delete",
+		"args": {"current": true}
+	},
+	{
+		"caption": "ANF: Copy Current File",
+		"command": "advanced_new_file_copy"
+	},
+	{
+		"caption": "ANF: Cut to File",
+		"command": "advanced_new_file_cut_to_file"
+	},
+	{
+		"caption": "Preferences: AdvancedNewFile Settings",
+		"command": "edit_settings",
+		"args": {
+			"base_file": "${packages}/AdvancedNewFile/AdvancedNewFile.sublime-settings",
+			"default": "// Settings in here override those in \"AdvancedNewFile/AdvancedNewFile.sublime-settings\".\n{\n\t$0\n}\n"
+		}
+	},
+	{
+		"caption": "Preferences: AdvancedNewFile Key Bindings",
+		"command": "edit_settings",
+		"args": {
+			"base_file": "${packages}/AdvancedNewFile/Default ($platform).sublime-keymap",
+			"default": "[\n\t$0\n]\n"
+		}
+	}
 ]

--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -1,90 +1,46 @@
 [
-    {
-        "caption": "Preferences",
-        "mnemonic": "n",
-        "id": "preferences",
-        "children":
-        [
-            {
-                "caption": "Package Settings",
-                "mnemonic": "P",
-                "id": "package-settings",
-                "children":
-                [
-                    {
-                        "caption": "AdvancedNewFile",
-                        "children":
-                        [
-                            {
-                                "command": "open_file",
-                                "args": {"file": "${packages}/AdvancedNewFile/README.md"},
-                                "caption": "README"
-                            },
-                            { "caption": "-" },
-                            {
-                                "command": "open_file",
-                                "args": {"file": "${packages}/AdvancedNewFile/AdvancedNewFile.sublime-settings"},
-                                "caption": "Settings – Default"
-                            },
-                            {
-                                "command": "open_file",
-                                "args": {"file": "${packages}/User/AdvancedNewFile.sublime-settings"},
-                                "caption": "Settings – User"
-                            },
-                            { "caption": "-" },
-                            {
-                                "command": "open_file",
-                                "args": {
-                                    "file": "${packages}/AdvancedNewFile/Default (OSX).sublime-keymap",
-                                    "platform": "OSX"
-                                },
-                                "caption": "Key Bindings – Default"
-                            },
-                            {
-                                "command": "open_file",
-                                "args": {
-                                    "file": "${packages}/AdvancedNewFile/Default (Linux).sublime-keymap",
-                                    "platform": "Linux"
-                                },
-                                "caption": "Key Bindings – Default"
-                            },
-                            {
-                                "command": "open_file",
-                                "args": {
-                                    "file": "${packages}/AdvancedNewFile/Default (Windows).sublime-keymap",
-                                    "platform": "Windows"
-                                },
-                                "caption": "Key Bindings – Default"
-                            },
-                            {
-                                "command": "open_file",
-                                "args": {
-                                    "file": "${packages}/User/Default (OSX).sublime-keymap",
-                                    "platform": "OSX"
-                                },
-                                "caption": "Key Bindings – User"
-                            },
-                            {
-                                "command": "open_file",
-                                "args": {
-                                    "file": "${packages}/User/Default (Linux).sublime-keymap",
-                                    "platform": "Linux"
-                                },
-                                "caption": "Key Bindings – User"
-                            },
-                            {
-                                "command": "open_file",
-                                "args": {
-                                    "file": "${packages}/User/Default (Windows).sublime-keymap",
-                                    "platform": "Windows"
-                                },
-                                "caption": "Key Bindings – User"
-                            },
-                            { "caption": "-" }
-                        ]
-                    }
-                ]
-            }
-        ]
-    }
+	{
+		"caption": "Preferences",
+		"mnemonic": "n",
+		"id": "preferences",
+		"children":
+		[
+			{
+				"caption": "Package Settings",
+				"mnemonic": "P",
+				"id": "package-settings",
+				"children":
+				[
+					{
+						"caption": "AdvancedNewFile",
+						"children":
+						[
+							{
+								"caption": "README",
+								"command": "open_file",
+								"args": {"file": "${packages}/AdvancedNewFile/README.md"}
+							},
+							{ "caption": "-" },
+							{
+								"caption": "Settings",
+								"command": "edit_settings",
+								"args": {
+									"base_file": "${packages}/AdvancedNewFile/AdvancedNewFile.sublime-settings",
+									"default": "// Settings in here override those in \"AdvancedNewFile/AdvancedNewFile.sublime-settings\".\n{\n\t$0\n}\n"
+								}
+							},
+							{
+								"caption": "Key Bindings",
+								"command": "edit_settings",
+								"args": {
+									"base_file": "${packages}/AdvancedNewFile/Default ($platform).sublime-keymap",
+									"default": "[\n\t$0\n]\n"
+								}
+							}
+						]
+					}
+				]
+			}
+		]
+	}
 ]


### PR DESCRIPTION
This commit...

1. replaces old `open_file` commands by `edit_settings` to edit user settings.
2. adds command palette items to edit preferences.

This breaks compatibility with ST2, but anything below ST 3143 is no longer supported by Package Control 4 anyway.